### PR TITLE
fix: livekit 서버 도메인 불일치

### DIFF
--- a/terraform/environments/dev/v2/outputs.tf
+++ b/terraform/environments/dev/v2/outputs.tf
@@ -14,10 +14,10 @@ output "livekit_server_instance_ids" {
 
 output "livekit_websocket_url" {
   description = "LiveKit WebSocket URL (API 서버 내부 통신용)"
-  value       = "ws://rtc-dev.sodam.store:7880"
+  value       = "ws://livekit.sodam.store:7880"
 }
 
 output "livekit_public_url" {
   description = "LiveKit Public URL (클라이언트 WebRTC 연결용)"
-  value       = "wss://rtc-dev.sodam.store"
+  value       = "wss://livekit.sodam.store"
 }

--- a/terraform/environments/dev/v2/route53.tf
+++ b/terraform/environments/dev/v2/route53.tf
@@ -16,7 +16,7 @@ data "aws_route53_zone" "main" {
 # -----------------------------------------------------------------------------
 resource "aws_route53_record" "livekit_dev" {
   zone_id = data.aws_route53_zone.main.zone_id
-  name    = "rtc-dev.sodam.store" # LiveKit 개발 서버 서브도메인
+  name    = "livekit.sodam.store" # LiveKit 개발 서버 서브도메인
   type    = "A"
   ttl     = 60 # 1분 (개발 환경, IP 변경 시 빠른 전파)
 


### PR DESCRIPTION


- livekit 서버 HOST url을 변경하는 중 미처 못바꾼 것

    - 전: rtc-dev.sodam.store
    - 후: livekit.sodam.store
